### PR TITLE
Create GitHub build actions for x64 and ARM64 architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+            arch: x64
+          - os: windows-11-arm
+            rid: win-arm64
+            arch: arm64
+
+    runs-on: ${{ matrix.os }}
+    name: Windows ${{ matrix.arch }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore src/Yoink/Yoink.csproj -r ${{ matrix.rid }}
+
+      - name: Publish
+        run: >
+          dotnet publish src/Yoink/Yoink.csproj
+          -c Release
+          -r ${{ matrix.rid }}
+          --self-contained true
+          -p:PublishSingleFile=true
+          -o publish
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Yoink-${{ matrix.rid }}
+          path: publish/
+          if-no-files-found: error


### PR DESCRIPTION
Adds GitHub build actions that creates artifacts for x64 and ARM 64 architectures. I tested the Windows ARM 64 version on my Lenovo Yoga Slim 7x (Snapdragon X Elite) running Windows 11 ARM 25H2.