### PR TITLE
Add temporary capture overlay workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ tests/
 .idea/
 *.sln.iml
 .vscode/
+.claude/
+.codex-tmp/
 
 ## Release artifacts
 release-hdr/

--- a/src/OddSnap.AppModel/Settings/SettingsSchemaCatalog.cs
+++ b/src/OddSnap.AppModel/Settings/SettingsSchemaCatalog.cs
@@ -34,6 +34,21 @@ public static class SettingsSchemaCatalog
                         new SettingDefinition("auto_updates", "Check for updates", SettingsValueKind.Toggle, "Look for new releases on startup.", "AutoCheckForUpdates"),
                         new SettingDefinition("after_capture", "After capture behavior", SettingsValueKind.Choice, "Default post-capture action.", "AfterCapture"),
                     ]),
+                new SettingsSectionDefinition(
+                    "temporary_overlay",
+                    "Temporary overlay",
+                    "Shottr-style workflow: keep new captures in memory until you explicitly Save them. Disables auto-save and skips history-on-capture; the Save button on the preview becomes the only permanent write path.",
+                    [
+                        new SettingDefinition("temporary_capture_mode", "Temporary capture mode", SettingsValueKind.Toggle, "Show new captures in a temporary overlay instead of saving them automatically.", "TemporaryCaptureMode"),
+                        new SettingDefinition("overlay_timeout", "Overlay timeout", SettingsValueKind.Choice, "How long the temporary overlay stays on screen before auto-dismissing.", "OverlayTimeoutSeconds",
+                        [
+                            new("5",  "5 seconds"),
+                            new("10", "10 seconds"),
+                            new("30", "30 seconds"),
+                            new("0",  "Never"),
+                        ]),
+                        new SettingDefinition("copy_after_capture", "Copy to clipboard automatically", SettingsValueKind.Toggle, "Copy the temporary capture to the clipboard as soon as it is taken.", "CopyAfterCapture"),
+                    ]),
             ]),
         new(
             "capture",

--- a/src/OddSnap/App/App.Capture.Handlers.cs
+++ b/src/OddSnap/App/App.Capture.Handlers.cs
@@ -15,6 +15,16 @@ public partial class App
     private void HandleCaptureResult(Bitmap result, bool useAiRedirect = false)
     {
         var settings = _settingsService!.Settings;
+
+        // Shottr-style flow: keep the capture in memory and show a temporary overlay.
+        // No file is written and no history entry is created until the user clicks Save.
+        // AI Redirect requires a saved file, so this branch is intentionally skipped when useAiRedirect is true.
+        if (settings.TemporaryCaptureMode && !useAiRedirect)
+        {
+            HandleTemporaryCaptureResult(result, settings);
+            return;
+        }
+
         var ext = CaptureOutputService.GetExtension(settings.CaptureImageFormat);
         string? requestedPath = null;
         if (settings.SaveToFile)
@@ -100,6 +110,50 @@ public partial class App
                     ScheduleIdleMemoryTrim();
                 });
             }, TaskScheduler.Default);
+    }
+
+    private void HandleTemporaryCaptureResult(Bitmap result, AppSettings settings)
+    {
+        // Critical invariant: PermanentPath stays null for this flow. The Save button
+        // on the toast preview is the only path that writes to disk and creates a
+        // history entry. We skip PersistCaptureAsync (and history-on-capture)
+        // entirely so the user owns the persistence decision.
+        Dispatcher.BeginInvoke(() =>
+        {
+            ResetCapturing();
+
+            Bitmap? preview = null;
+            try
+            {
+                preview = CaptureOutputService.PrepareBitmap(result, settings.CaptureMaxLongEdge);
+
+                if (settings.CopyAfterCapture)
+                    TryCopyCaptureOutputToClipboard(preview);
+
+                bool autoPin = settings.AutoPinPreviews || settings.OverlayTimeoutSeconds == 0;
+                if (autoPin)
+                    ToastWindow.ShowImagePreview(preview, filePath: null, autoPin: true);
+                else
+                    ToastWindow.ShowImagePreviewWithDuration(preview, filePath: null, autoPin: false, settings.OverlayTimeoutSeconds);
+
+                // Toast now owns the preview bitmap.
+                preview = null;
+            }
+            catch (Exception ex)
+            {
+                preview?.Dispose();
+                ShowCaptureProcessingFailed(
+                    "Capture error",
+                    "OddSnap could not finish the capture. Try again, or turn off Temporary capture mode in Settings -> General.",
+                    ex.Message);
+            }
+            finally
+            {
+                result.Dispose();
+            }
+
+            ScheduleIdleMemoryTrim();
+        });
     }
 
     private void HandleStickerResult(Bitmap result, string providerName)

--- a/src/OddSnap/App/App.Lifecycle.cs
+++ b/src/OddSnap/App/App.Lifecycle.cs
@@ -199,6 +199,30 @@ public partial class App
         }
     }
 
+    // Called from the toast preview's Save flow so the temporary-overlay workflow can
+    // register the file it just wrote without depending on the auto-save pipeline.
+    // Returns the created HistoryEntry on success, or null when history is disabled or unavailable.
+    internal static HistoryEntry? TryTrackSavedCapture(string filePath, int width, int height, HistoryKind kind = HistoryKind.Image)
+    {
+        if (Application.Current is not App app || app._settingsService is null)
+            return null;
+
+        if (!app._settingsService.Settings.SaveHistory)
+            return null;
+
+        try
+        {
+            var entry = app.EnsureHistoryService().TrackExistingCapture(filePath, width, height, kind);
+            SettingsWindow.WarmRecentHistoryThumbs(new[] { entry }, maxCount: 1);
+            return entry;
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogError("toast.track-saved-capture", ex, $"Failed to track {System.IO.Path.GetFileName(filePath)} in history.");
+            return null;
+        }
+    }
+
     private ImageSearchIndexService EnsureImageSearchIndexService()
     {
         lock (_historyGate)

--- a/src/OddSnap/App/App.Shutdown.cs
+++ b/src/OddSnap/App/App.Shutdown.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using OddSnap.Services;
+using OddSnap.UI;
 
 namespace OddSnap;
 
@@ -8,6 +9,7 @@ public partial class App
     protected override void OnExit(ExitEventArgs e)
     {
         _idleTrimTimer?.Stop();
+        try { PinnedCaptureWindow.CloseAll(); } catch (Exception ex) { AppDiagnostics.LogError("shutdown.close-pinned-captures", ex); }
         try { BackgroundRuntimeJobService.CancelAllRunningJobs(); } catch (Exception ex) { AppDiagnostics.LogError("shutdown.cancel-runtime-jobs", ex); }
         _hotkeyService?.Dispose();
         try { _settingsService?.Dispose(); } catch (Exception ex) { AppDiagnostics.LogError("shutdown.dispose-settings", ex); }

--- a/src/OddSnap/App/App.Startup.cs
+++ b/src/OddSnap/App/App.Startup.cs
@@ -136,6 +136,43 @@ public partial class App
                 AppDiagnostics.LogError("startup.preload-history-search", ex);
             }
         });
+
+        _ = Task.Run(SweepOrphanedTemporaryDragFiles);
+    }
+
+    // Garbage-collect drag-out temp PNGs left behind by crashed drag operations.
+    // The toast and PinnedCaptureWindow each clean up their own temp files on success;
+    // this sweep catches the ones a process kill leaves behind.
+    private static void SweepOrphanedTemporaryDragFiles()
+    {
+        try
+        {
+            var tempDir = System.IO.Path.GetTempPath();
+            if (!System.IO.Directory.Exists(tempDir))
+                return;
+
+            var cutoff = DateTime.UtcNow - TimeSpan.FromHours(1);
+            foreach (var pattern in new[] { "oddsnap_toast_*.png", "oddsnap_pin_*.png" })
+            {
+                foreach (var file in System.IO.Directory.EnumerateFiles(tempDir, pattern, System.IO.SearchOption.TopDirectoryOnly))
+                {
+                    try
+                    {
+                        var info = new System.IO.FileInfo(file);
+                        if (info.LastWriteTimeUtc < cutoff)
+                            info.Delete();
+                    }
+                    catch (Exception ex)
+                    {
+                        AppDiagnostics.LogWarning("startup.sweep-temp-drag", $"Could not delete orphaned drag file {System.IO.Path.GetFileName(file)}: {ex.Message}", ex);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogWarning("startup.sweep-temp-drag", ex.Message, ex);
+        }
     }
 
     private void ConfigureTrayIcon()

--- a/src/OddSnap/Helpers/ToastButtonLayout.cs
+++ b/src/OddSnap/Helpers/ToastButtonLayout.cs
@@ -10,7 +10,8 @@ public enum ToastButtonKind
     Save,
     Office,
     AiRedirect,
-    Delete
+    Delete,
+    Copy
 }
 
 public static class ToastButtonLayout
@@ -38,6 +39,7 @@ public static class ToastButtonLayout
             ToastButtonKind.Close => settings.CloseSlot,
             ToastButtonKind.Pin => settings.PinSlot,
             ToastButtonKind.Save => settings.SaveSlot,
+            ToastButtonKind.Copy => settings.CopySlot,
             ToastButtonKind.Office => settings.OfficeSlot,
             ToastButtonKind.AiRedirect => settings.AiRedirectSlot,
             _ => settings.DeleteSlot
@@ -49,6 +51,7 @@ public static class ToastButtonLayout
             ToastButtonKind.Close => settings.ShowClose,
             ToastButtonKind.Pin => settings.ShowPin,
             ToastButtonKind.Save => settings.ShowSave,
+            ToastButtonKind.Copy => settings.ShowCopy,
             ToastButtonKind.Office => settings.ShowOffice,
             ToastButtonKind.AiRedirect => settings.ShowAiRedirect,
             _ => settings.ShowDelete
@@ -61,6 +64,7 @@ public static class ToastButtonLayout
             case ToastButtonKind.Close: settings.ShowClose = visible; break;
             case ToastButtonKind.Pin: settings.ShowPin = visible; break;
             case ToastButtonKind.Save: settings.ShowSave = visible; break;
+            case ToastButtonKind.Copy: settings.ShowCopy = visible; break;
             case ToastButtonKind.Office: settings.ShowOffice = visible; break;
             case ToastButtonKind.AiRedirect: settings.ShowAiRedirect = visible; break;
             default: settings.ShowDelete = visible; break;
@@ -84,6 +88,7 @@ public static class ToastButtonLayout
         if (settings.CloseSlot == slot) return ToastButtonKind.Close;
         if (settings.PinSlot == slot) return ToastButtonKind.Pin;
         if (settings.SaveSlot == slot) return ToastButtonKind.Save;
+        if (settings.CopySlot == slot) return ToastButtonKind.Copy;
         if (settings.OfficeSlot == slot) return ToastButtonKind.Office;
         if (settings.AiRedirectSlot == slot) return ToastButtonKind.AiRedirect;
         if (settings.DeleteSlot == slot) return ToastButtonKind.Delete;
@@ -97,6 +102,7 @@ public static class ToastButtonLayout
             case ToastButtonKind.Close: settings.CloseSlot = slot; break;
             case ToastButtonKind.Pin: settings.PinSlot = slot; break;
             case ToastButtonKind.Save: settings.SaveSlot = slot; break;
+            case ToastButtonKind.Copy: settings.CopySlot = slot; break;
             case ToastButtonKind.Office: settings.OfficeSlot = slot; break;
             case ToastButtonKind.AiRedirect: settings.AiRedirectSlot = slot; break;
             default: settings.DeleteSlot = slot; break;

--- a/src/OddSnap/Localization/en.json
+++ b/src/OddSnap/Localization/en.json
@@ -221,5 +221,18 @@
   "Update available": "Update available",
   "Update failed": "Update failed",
   "Update check failed": "Update check failed",
-  "OddSnap is up to date": "OddSnap is up to date"
+  "OddSnap is up to date": "OddSnap is up to date",
+  "Temporary overlay": "Temporary overlay",
+  "Temporary capture mode": "Temporary capture mode",
+  "Overlay timeout": "Overlay timeout",
+  "Copy to clipboard automatically": "Copy to clipboard automatically",
+  "Copy preview": "Copy preview",
+  "Copy failed": "Copy failed",
+  "Save to disk": "Save to disk",
+  "Copy to clipboard": "Copy to clipboard",
+  "Discard pinned capture": "Discard pinned capture",
+  "Save pinned capture": "Save pinned capture",
+  "Copy pinned capture": "Copy pinned capture",
+  "Window opacity": "Window opacity",
+  "Pinned capture opacity": "Pinned capture opacity"
 }

--- a/src/OddSnap/Models/AppSettings.cs
+++ b/src/OddSnap/Models/AppSettings.cs
@@ -118,6 +118,8 @@ public sealed class AppSettings
         public ToastButtonSlot PinSlot { get; set; } = ToastButtonSlot.TopLeft;
         public bool ShowSave { get; set; } = true;
         public ToastButtonSlot SaveSlot { get; set; } = ToastButtonSlot.BottomRight;
+        public bool ShowCopy { get; set; } = true;
+        public ToastButtonSlot CopySlot { get; set; } = ToastButtonSlot.TopInnerRight;
         public bool ShowOffice { get; set; }
         public ToastButtonSlot OfficeSlot { get; set; } = ToastButtonSlot.TopInnerLeft;
         public bool ShowAiRedirect { get; set; } = true;
@@ -230,6 +232,14 @@ public sealed class AppSettings
     public double ToastFadeOutSeconds { get; set; } = 1.0;
     public bool AutoPinPreviews { get; set; }
     public ToastButtonLayoutSettings ToastButtons { get; set; } = new();
+
+    // Shottr-style temporary overlay: keep captures in memory until the user clicks Save.
+    // Off by default to preserve auto-save behavior for existing installs.
+    public bool TemporaryCaptureMode { get; set; }
+    // Seconds before the temporary overlay auto-dismisses. 0 = never (pin permanently).
+    public int OverlayTimeoutSeconds { get; set; } = 10;
+    // Whether to copy the temporary capture to the clipboard automatically on capture.
+    public bool CopyAfterCapture { get; set; }
     public Dictionary<string, string> OpenWithApps { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public SoundPack SoundPack { get; set; } = SoundPack.Default;
 

--- a/src/OddSnap/Services/SettingsService.cs
+++ b/src/OddSnap/Services/SettingsService.cs
@@ -343,8 +343,20 @@ public sealed class SettingsService : IDisposable
 
         NormalizeUnsafeModifierlessHotkeys(settings);
         NormalizeToastButtonLayout(settings.ToastButtons);
+        NormalizeOverlayTimeoutSeconds(settings);
 
         return settings;
+    }
+
+    private static void NormalizeOverlayTimeoutSeconds(AppSettings settings)
+    {
+        // 0 = never (auto-pin); otherwise clamp to a sensible range.
+        if (settings.OverlayTimeoutSeconds < 0)
+            settings.OverlayTimeoutSeconds = 8;
+        else if (settings.OverlayTimeoutSeconds > 0 && settings.OverlayTimeoutSeconds < 1)
+            settings.OverlayTimeoutSeconds = 1;
+        else if (settings.OverlayTimeoutSeconds > 60)
+            settings.OverlayTimeoutSeconds = 60;
     }
 
     private static void NormalizeEnums(AppSettings settings)
@@ -434,6 +446,7 @@ public sealed class SettingsService : IDisposable
         settings.CloseSlot = TakeSlot(settings.CloseSlot, ToastButtonSlot.TopRight, used);
         settings.PinSlot = TakeSlot(settings.PinSlot, ToastButtonSlot.TopLeft, used);
         settings.SaveSlot = TakeSlot(settings.SaveSlot, ToastButtonSlot.BottomRight, used);
+        settings.CopySlot = TakeSlot(settings.CopySlot, ToastButtonSlot.TopInnerRight, used);
         settings.OfficeSlot = TakeSlot(settings.OfficeSlot, ToastButtonSlot.TopInnerLeft, used);
         settings.AiRedirectSlot = TakeSlot(settings.AiRedirectSlot, ToastButtonSlot.BottomLeft, used);
         settings.DeleteSlot = TakeSlot(settings.DeleteSlot, ToastButtonSlot.BottomInnerRight, used);

--- a/src/OddSnap/UI/PinnedCaptureWindow.xaml
+++ b/src/OddSnap/UI/PinnedCaptureWindow.xaml
@@ -1,0 +1,95 @@
+<Window x:Class="OddSnap.UI.PinnedCaptureWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        ShowInTaskbar="False"
+        Topmost="True"
+        ResizeMode="CanResizeWithGrip"
+        Background="Transparent"
+        SizeToContent="Manual"
+        WindowStartupLocation="Manual"
+        UseLayoutRounding="True"
+        Focusable="False"
+        ShowActivated="False"
+        MinWidth="120"
+        MinHeight="80">
+
+    <Border x:Name="OuterShell"
+            CornerRadius="12"
+            Background="#202020"
+            BorderBrush="#3F3F3F"
+            BorderThickness="1"
+            Padding="0"
+            SnapsToDevicePixels="True">
+        <Grid>
+            <Border x:Name="ImageFrame" CornerRadius="11" ClipToBounds="True">
+                <Image x:Name="PreviewImage" Stretch="Uniform"
+                       UseLayoutRounding="True"
+                       SnapsToDevicePixels="True"
+                       RenderOptions.BitmapScalingMode="HighQuality"
+                       Cursor="SizeAll"/>
+            </Border>
+
+            <Border x:Name="ActionBar"
+                    HorizontalAlignment="Center" VerticalAlignment="Top"
+                    Margin="0,8,0,0"
+                    CornerRadius="8"
+                    Background="#CC202020"
+                    BorderBrush="#3F3F3F"
+                    BorderThickness="1"
+                    Padding="4"
+                    Opacity="0">
+                <StackPanel Orientation="Horizontal">
+                    <Border x:Name="CopyBtn" Width="32" Height="32" CornerRadius="8"
+                            Background="Transparent" BorderBrush="Transparent" BorderThickness="0"
+                            ToolTip="Copy to clipboard"
+                            AutomationProperties.Name="Copy pinned capture"
+                            AutomationProperties.HelpText="Copy this pinned screenshot to the clipboard."
+                            Cursor="Hand"
+                            Focusable="True"
+                            Margin="0,0,2,0"
+                            KeyDown="CopyBtn_KeyDown">
+                        <Image x:Name="CopyIcon" Width="16" Height="16" Stretch="Uniform"
+                               RenderOptions.BitmapScalingMode="HighQuality"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border x:Name="SaveBtn" Width="32" Height="32" CornerRadius="8"
+                            Background="Transparent" BorderBrush="Transparent" BorderThickness="0"
+                            ToolTip="Save to disk"
+                            AutomationProperties.Name="Save pinned capture"
+                            AutomationProperties.HelpText="Save this pinned screenshot to disk."
+                            Cursor="Hand"
+                            Focusable="True"
+                            Margin="0,0,2,0"
+                            KeyDown="SaveBtn_KeyDown">
+                        <Image x:Name="SaveIcon" Width="16" Height="16" Stretch="Uniform"
+                               RenderOptions.BitmapScalingMode="HighQuality"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Slider x:Name="OpacitySlider"
+                            Minimum="0.3" Maximum="1.0" Value="1.0"
+                            Width="80" Margin="6,0,6,0"
+                            VerticalAlignment="Center"
+                            IsSnapToTickEnabled="False"
+                            ToolTip="Window opacity"
+                            AutomationProperties.Name="Pinned capture opacity"
+                            AutomationProperties.HelpText="Adjust the opacity of this pinned screenshot window."
+                            ValueChanged="OpacitySlider_ValueChanged"/>
+                    <Border x:Name="CloseBtn" Width="32" Height="32" CornerRadius="8"
+                            Background="Transparent" BorderBrush="Transparent" BorderThickness="0"
+                            ToolTip="Discard pinned capture"
+                            AutomationProperties.Name="Discard pinned capture"
+                            AutomationProperties.HelpText="Discard this pinned screenshot."
+                            Cursor="Hand"
+                            Focusable="True"
+                            KeyDown="CloseBtn_KeyDown">
+                        <Image x:Name="CloseIcon" Width="16" Height="16" Stretch="Uniform"
+                               RenderOptions.BitmapScalingMode="HighQuality"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/OddSnap/UI/PinnedCaptureWindow.xaml.cs
+++ b/src/OddSnap/UI/PinnedCaptureWindow.xaml.cs
@@ -1,0 +1,342 @@
+using Bitmap = System.Drawing.Bitmap;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using OddSnap.Helpers;
+using OddSnap.Services;
+using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
+
+namespace OddSnap.UI;
+
+// Borderless, always-on-top "floating screenshot" window — spawned when the user
+// clicks Pin on a temporary toast preview. Owns its bitmap until the window closes.
+// Permanent disk writes only happen when the user clicks Save here.
+public partial class PinnedCaptureWindow : Window
+{
+    private static readonly List<PinnedCaptureWindow> s_instances = new();
+
+    private Bitmap? _bitmap;
+    private string? _savedFilePath;
+    private bool _isCopying;
+    private bool _isSaving;
+    private bool _isDragging;
+    private bool _actionBarVisible;
+    private System.Windows.Point _dragStart;
+    private static readonly System.Drawing.Color IconWhite = System.Drawing.Color.FromArgb(230, 255, 255, 255);
+
+    public PinnedCaptureWindow(Bitmap bitmap, string? savedFilePath = null)
+    {
+        _bitmap = bitmap;
+        _savedFilePath = savedFilePath;
+        InitializeComponent();
+        Theme.Refresh();
+        OddSnapWindowChrome.ApplyRoundedCorners(this, 12);
+        UiScale.ApplyToWindow(this, OuterShell, scaleWindowBounds: false);
+
+        ApplyThemeChrome();
+        LoadActionIcons();
+        HookActionBarHover();
+        HookActionBarClicks();
+
+        PreviewImage.Source = BitmapPerf.ToBitmapSource(bitmap);
+        SizeToInitialBounds(bitmap);
+        PlaceNearScreenCenter();
+
+        ImageFrame.MouseLeftButtonDown += ImageFrame_MouseLeftButtonDown;
+        ImageFrame.MouseMove += ImageFrame_MouseMove;
+        ImageFrame.MouseLeftButtonUp += ImageFrame_MouseLeftButtonUp;
+
+        Closed += (_, _) =>
+        {
+            s_instances.Remove(this);
+            _bitmap?.Dispose();
+            _bitmap = null;
+            PreviewImage.Source = null;
+        };
+
+        s_instances.Add(this);
+    }
+
+    public static void CloseAll()
+    {
+        foreach (var win in s_instances.ToArray())
+        {
+            try { win.Close(); }
+            catch (System.Exception ex) { AppDiagnostics.LogWarning("pin.close-all", ex.Message, ex); }
+        }
+    }
+
+    private void ApplyThemeChrome()
+    {
+        OuterShell.Background = Theme.Brush(Theme.IsDark
+            ? System.Windows.Media.Color.FromRgb(28, 28, 28)
+            : System.Windows.Media.Color.FromRgb(248, 248, 248));
+        OuterShell.BorderBrush = Theme.Brush(Theme.IsDark
+            ? System.Windows.Media.Color.FromRgb(63, 63, 63)
+            : System.Windows.Media.Color.FromRgb(214, 214, 214));
+        ActionBar.Background = Theme.Brush(Theme.IsDark
+            ? System.Windows.Media.Color.FromArgb(220, 32, 32, 32)
+            : System.Windows.Media.Color.FromArgb(232, 248, 248, 248));
+        ActionBar.BorderBrush = OuterShell.BorderBrush;
+    }
+
+    private void LoadActionIcons()
+    {
+        CopyIcon.Source = FluentIcons.RenderWpf("copy", IconWhite, 20);
+        SaveIcon.Source = FluentIcons.RenderWpf("download", IconWhite, 20);
+        CloseIcon.Source = FluentIcons.RenderWpf("close", IconWhite, 20);
+        ApplyButtonVisual(CopyBtn, CopyIcon, "copy", active: false);
+        ApplyButtonVisual(SaveBtn, SaveIcon, "download", active: false);
+        ApplyButtonVisual(CloseBtn, CloseIcon, "close", active: false);
+    }
+
+    private void HookActionBarHover()
+    {
+        MouseEnter += (_, _) => SetActionBarVisible(true);
+        MouseLeave += (_, _) => SetActionBarVisible(false);
+
+        HookHover(CopyBtn, CopyIcon, "copy");
+        HookHover(SaveBtn, SaveIcon, "download");
+        HookHover(CloseBtn, CloseIcon, "close");
+    }
+
+    private void HookHover(System.Windows.Controls.Border btn, System.Windows.Controls.Image icon, string iconId)
+    {
+        btn.MouseEnter += (_, _) => ApplyButtonVisual(btn, icon, iconId, active: true);
+        btn.MouseLeave += (_, _) => ApplyButtonVisual(btn, icon, iconId, active: false);
+    }
+
+    private void HookActionBarClicks()
+    {
+        CopyBtn.MouseLeftButtonDown += (s, e) => { e.Handled = true; CopyToClipboard(); };
+        SaveBtn.MouseLeftButtonDown += (s, e) => { e.Handled = true; SaveToDisk(); };
+        CloseBtn.MouseLeftButtonDown += (s, e) => { e.Handled = true; Close(); };
+    }
+
+    private static void ApplyButtonVisual(System.Windows.Controls.Border btn, System.Windows.Controls.Image icon, string iconId, bool active)
+    {
+        btn.Background = Theme.Brush(active
+            ? (Theme.IsDark ? System.Windows.Media.Color.FromRgb(70, 70, 70) : System.Windows.Media.Color.FromRgb(226, 226, 226))
+            : (Theme.IsDark ? System.Windows.Media.Color.FromRgb(48, 48, 48) : System.Windows.Media.Color.FromRgb(246, 246, 246)));
+        btn.BorderBrush = System.Windows.Media.Brushes.Transparent;
+        btn.BorderThickness = new Thickness(0);
+        var iconColor = Theme.IsDark
+            ? System.Drawing.Color.FromArgb(255, 255, 255, 255)
+            : System.Drawing.Color.FromArgb(255, 24, 24, 24);
+        icon.Source = FluentIcons.RenderWpf(iconId, iconColor, 22, active);
+    }
+
+    private void SetActionBarVisible(bool visible)
+    {
+        if (_actionBarVisible == visible)
+            return;
+        _actionBarVisible = visible;
+        ActionBar.BeginAnimation(OpacityProperty, Motion.To(visible ? 1.0 : 0.0, 150, Motion.SmoothOut));
+    }
+
+    private void SizeToInitialBounds(Bitmap bitmap)
+    {
+        // Cap initial size at half the work area so very large captures don't span the screen.
+        var wa = PopupWindowHelper.GetCurrentWorkArea();
+        double maxW = wa.Width * 0.5;
+        double maxH = wa.Height * 0.5;
+        double w = bitmap.Width;
+        double h = bitmap.Height;
+        if (w <= 0 || h <= 0) { w = 320; h = 240; }
+        double scale = System.Math.Min(1.0, System.Math.Min(maxW / w, maxH / h));
+        Width = System.Math.Max(MinWidth, w * scale);
+        Height = System.Math.Max(MinHeight, h * scale);
+    }
+
+    private void PlaceNearScreenCenter()
+    {
+        var wa = PopupWindowHelper.GetCurrentWorkArea();
+        Left = wa.X + (wa.Width - Width) / 2;
+        Top = wa.Y + (wa.Height - Height) / 2;
+    }
+
+    private void OpacitySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        Opacity = System.Math.Clamp(e.NewValue, 0.3, 1.0);
+    }
+
+    private void CopyBtn_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key is not (Key.Enter or Key.Space)) return;
+        e.Handled = true;
+        CopyToClipboard();
+    }
+
+    private void SaveBtn_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key is not (Key.Enter or Key.Space)) return;
+        e.Handled = true;
+        SaveToDisk();
+    }
+
+    private void CloseBtn_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key is not (Key.Enter or Key.Space)) return;
+        e.Handled = true;
+        Close();
+    }
+
+    private void CopyToClipboard()
+    {
+        if (_bitmap is null || _isCopying)
+            return;
+
+        _isCopying = true;
+        CopyBtn.IsEnabled = false;
+        try
+        {
+            ClipboardService.CopyToClipboard(_bitmap, !string.IsNullOrWhiteSpace(_savedFilePath) && File.Exists(_savedFilePath) ? _savedFilePath : null);
+            ToastWindow.Show(ToastSpec.Standard("Copied", string.Empty) with { SuppressSound = true });
+        }
+        catch (System.Exception ex)
+        {
+            ToastWindow.ShowError("Copy failed",
+                $"OddSnap could not copy the pinned capture to the clipboard. Try again or save the file and copy it manually.\n{ex.Message}");
+        }
+        finally
+        {
+            _isCopying = false;
+            CopyBtn.IsEnabled = true;
+        }
+    }
+
+    private void SaveToDisk()
+    {
+        if (_bitmap is null || _isSaving)
+            return;
+
+        _isSaving = true;
+        SaveBtn.IsEnabled = false;
+        try
+        {
+            var settings = SettingsService.LoadStatic();
+            bool quickSave =
+                _savedFilePath is null
+                && settings is { AskForFileNameOnSave: false }
+                && !string.IsNullOrWhiteSpace(settings.SaveDirectory);
+
+            if (quickSave)
+            {
+                QuickSave(settings!);
+                return;
+            }
+
+            var dlg = new SaveFileDialog
+            {
+                FileName = _savedFilePath != null ? Path.GetFileName(_savedFilePath) : "screenshot.png",
+                Filter = "PNG|*.png|JPEG|*.jpg|BMP|*.bmp"
+            };
+            if (dlg.ShowDialog(this) != true)
+                return;
+
+            var format = dlg.FilterIndex switch
+            {
+                2 => Models.CaptureImageFormat.Jpeg,
+                3 => Models.CaptureImageFormat.Bmp,
+                _ => Models.CaptureImageFormat.Png
+            };
+
+            try
+            {
+                CaptureOutputService.SaveBitmap(_bitmap, dlg.FileName, format, jpegQuality: settings?.JpegQuality ?? 92);
+                _savedFilePath = dlg.FileName;
+                App.TryTrackSavedCapture(dlg.FileName, _bitmap.Width, _bitmap.Height);
+                ToastWindow.Show(ToastSpec.Standard("Saved", Path.GetFileName(dlg.FileName), dlg.FileName));
+            }
+            catch (System.Exception ex)
+            {
+                ToastWindow.ShowError("Save failed",
+                    $"OddSnap could not save the pinned capture. Choose another folder or check write permissions.\n{ex.Message}");
+            }
+        }
+        finally
+        {
+            _isSaving = false;
+            SaveBtn.IsEnabled = true;
+        }
+    }
+
+    private void QuickSave(Models.AppSettings settings)
+    {
+        if (_bitmap is null)
+            return;
+
+        var format = settings.CaptureImageFormat;
+        var extension = CaptureOutputService.GetExtension(format);
+        var baseName = Helpers.FileNameTemplate.Format(settings.FileNameTemplate, _bitmap.Width, _bitmap.Height);
+        var fileName = $"{baseName}.{extension}";
+        string savePath;
+        try
+        {
+            savePath = Helpers.CaptureSavePath.BuildAvailablePath(
+                settings.SaveDirectory,
+                fileName,
+                settings.SaveInMonthlyFolders);
+        }
+        catch (System.Exception ex)
+        {
+            ToastWindow.ShowError("Save failed",
+                $"OddSnap could not pick a save path. Check the save folder in Settings.\n{ex.Message}");
+            return;
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(savePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+            CaptureOutputService.SaveBitmap(_bitmap, savePath, format, settings.JpegQuality);
+        }
+        catch (System.Exception ex)
+        {
+            ToastWindow.ShowError("Save failed",
+                $"OddSnap could not save the pinned capture to the configured folder. Check Settings -> Saving.\n{ex.Message}");
+            return;
+        }
+
+        _savedFilePath = savePath;
+        App.TryTrackSavedCapture(savePath, _bitmap.Width, _bitmap.Height);
+        ToastWindow.Show(ToastSpec.Standard("Saved", Path.GetFileName(savePath), savePath));
+    }
+
+    // Plain left-drag on the image area moves the window. Drag-to-export is intentionally
+    // only supported from the toast overlay (per spec). Users who want to drag the pinned
+    // screenshot into another app should Copy + paste or Save + drag from Explorer.
+    private void ImageFrame_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        _dragStart = e.GetPosition(this);
+        _isDragging = false;
+    }
+
+    private void ImageFrame_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+    {
+        if (e.LeftButton != MouseButtonState.Pressed)
+            return;
+
+        var diff = e.GetPosition(this) - _dragStart;
+        if (!_isDragging && System.Math.Abs(diff.X) < 5 && System.Math.Abs(diff.Y) < 5)
+            return;
+
+        _isDragging = true;
+        try
+        {
+            DragMove();
+        }
+        catch (System.InvalidOperationException)
+        {
+            // DragMove throws if the mouse button isn't down anymore; ignore.
+        }
+    }
+
+    private void ImageFrame_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        _isDragging = false;
+    }
+}

--- a/src/OddSnap/UI/Settings/SettingsWindow.Appearance.cs
+++ b/src/OddSnap/UI/Settings/SettingsWindow.Appearance.cs
@@ -159,6 +159,16 @@ public partial class SettingsWindow
         HdrCaptureCompatibleModeCheck.IsChecked = s.HdrCaptureCompatibleMode;
         ShowToolNumberBadgesCheck.IsChecked = s.ShowToolNumberBadges;
         AskFileNameCheck.IsChecked = s.AskForFileNameOnSave;
+        TemporaryCaptureModeCheck.IsChecked = s.TemporaryCaptureMode;
+        CopyAfterCaptureCheck.IsChecked = s.CopyAfterCapture;
+        OverlayTimeoutCombo.SelectedIndex = s.OverlayTimeoutSeconds switch
+        {
+            5 => 0,
+            10 => 1,
+            30 => 2,
+            0 => 3,
+            _ => 1
+        };
         MonthlyFoldersCheck.IsChecked = s.SaveInMonthlyFolders;
         LoadFileNameTemplate(s.FileNameTemplate);
         ToastPositionCombo.SelectedIndex = (int)s.ToastPosition;

--- a/src/OddSnap/UI/Settings/SettingsWindow.Toast.cs
+++ b/src/OddSnap/UI/Settings/SettingsWindow.Toast.cs
@@ -22,6 +22,16 @@ public partial class SettingsWindow
     private System.Windows.Point _toastDragStart;
     private ToastButtonKind _selectedBeforePress;
     private bool _pressedButtonWasHidden;
+    private static readonly ToastButtonKind[] ToastLayoutButtons =
+    [
+        ToastButtonKind.Close,
+        ToastButtonKind.Pin,
+        ToastButtonKind.Save,
+        ToastButtonKind.Copy,
+        ToastButtonKind.Office,
+        ToastButtonKind.AiRedirect,
+        ToastButtonKind.Delete
+    ];
 
     private AppSettings.ToastButtonLayoutSettings ToastButtons
     {
@@ -44,6 +54,7 @@ public partial class SettingsWindow
         ToastLayoutCloseIcon.Source = Helpers.FluentIcons.RenderWpf("close", iconColor, 20);
         ToastLayoutPinIcon.Source = Helpers.FluentIcons.RenderWpf("pin", iconColor, 20);
         ToastLayoutSaveIcon.Source = Helpers.FluentIcons.RenderWpf("download", iconColor, 20);
+        ToastLayoutCopyIcon.Source = Helpers.FluentIcons.RenderWpf("copy", iconColor, 20);
         ToastLayoutOfficeIcon.Source = Helpers.FluentIcons.RenderWpf("copy", iconColor, 20);
         ToastLayoutAiRedirectIcon.Source = Helpers.ToolIcons.RenderAiRedirectWpf(iconColor, 20);
         ToastLayoutDeleteIcon.Source = Helpers.FluentIcons.RenderWpf("trash", iconColor, 20);
@@ -60,6 +71,7 @@ public partial class SettingsWindow
         UpdateToastLayoutButton(ToastLayoutCloseBtn, ToastButtonKind.Close);
         UpdateToastLayoutButton(ToastLayoutPinBtn, ToastButtonKind.Pin);
         UpdateToastLayoutButton(ToastLayoutSaveBtn, ToastButtonKind.Save);
+        UpdateToastLayoutButton(ToastLayoutCopyBtn, ToastButtonKind.Copy);
         UpdateToastLayoutButton(ToastLayoutOfficeBtn, ToastButtonKind.Office);
         UpdateToastLayoutButton(ToastLayoutAiRedirectBtn, ToastButtonKind.AiRedirect);
         UpdateToastLayoutButton(ToastLayoutDeleteBtn, ToastButtonKind.Delete);
@@ -116,6 +128,9 @@ public partial class SettingsWindow
                 break;
             case ToastButtonKind.Save:
                 ToastLayoutSaveIcon.Source = Helpers.FluentIcons.RenderWpf("download", color, 22, active);
+                break;
+            case ToastButtonKind.Copy:
+                ToastLayoutCopyIcon.Source = Helpers.FluentIcons.RenderWpf("copy", color, 22, active);
                 break;
             case ToastButtonKind.Office:
                 ToastLayoutOfficeIcon.Source = Helpers.FluentIcons.RenderWpf("copy", color, 22, active);
@@ -353,6 +368,7 @@ public partial class SettingsWindow
     {
         "Pin" => ToastButtonKind.Pin,
         "Save" => ToastButtonKind.Save,
+        "Copy" => ToastButtonKind.Copy,
         "Office" => ToastButtonKind.Office,
         "AiRedirect" => ToastButtonKind.AiRedirect,
         "Delete" => ToastButtonKind.Delete,
@@ -384,7 +400,7 @@ public partial class SettingsWindow
         ToastHiddenShelfDropCue.Visibility = Visibility.Collapsed;
         ToastHiddenButtonsPanel.Children.Clear();
 
-        foreach (var button in new[] { ToastButtonKind.Close, ToastButtonKind.Pin, ToastButtonKind.Save, ToastButtonKind.Office, ToastButtonKind.AiRedirect, ToastButtonKind.Delete })
+        foreach (var button in ToastLayoutButtons)
         {
             if (ToastButtonLayout.IsVisible(ToastButtons, button))
                 continue;
@@ -423,6 +439,7 @@ public partial class SettingsWindow
             ToastButtonKind.Close => BuildCloseGlyph(),
             ToastButtonKind.Pin => BuildPinGlyph(),
             ToastButtonKind.Save => BuildSaveGlyph(),
+            ToastButtonKind.Copy => BuildCopyGlyph(),
             ToastButtonKind.Office => BuildOfficeGlyph(),
             ToastButtonKind.AiRedirect => BuildAiRedirectGlyph(),
             _ => BuildDeleteGlyph()
@@ -507,6 +524,7 @@ public partial class SettingsWindow
         if (IsPointOverElement(ToastLayoutCloseBtn, pos) && ToastLayoutCloseBtn.Visibility == Visibility.Visible) return ToastButtonKind.Close;
         if (IsPointOverElement(ToastLayoutPinBtn, pos) && ToastLayoutPinBtn.Visibility == Visibility.Visible) return ToastButtonKind.Pin;
         if (IsPointOverElement(ToastLayoutSaveBtn, pos) && ToastLayoutSaveBtn.Visibility == Visibility.Visible) return ToastButtonKind.Save;
+        if (IsPointOverElement(ToastLayoutCopyBtn, pos) && ToastLayoutCopyBtn.Visibility == Visibility.Visible) return ToastButtonKind.Copy;
         if (IsPointOverElement(ToastLayoutOfficeBtn, pos) && ToastLayoutOfficeBtn.Visibility == Visibility.Visible) return ToastButtonKind.Office;
         if (IsPointOverElement(ToastLayoutAiRedirectBtn, pos) && ToastLayoutAiRedirectBtn.Visibility == Visibility.Visible) return ToastButtonKind.AiRedirect;
         if (IsPointOverElement(ToastLayoutDeleteBtn, pos) && ToastLayoutDeleteBtn.Visibility == Visibility.Visible) return ToastButtonKind.Delete;
@@ -557,6 +575,7 @@ public partial class SettingsWindow
                 ToastButtonKind.Close => BuildCloseGlyph(),
                 ToastButtonKind.Pin => BuildPinGlyph(),
                 ToastButtonKind.Save => BuildSaveGlyph(),
+                ToastButtonKind.Copy => BuildCopyGlyph(),
                 ToastButtonKind.Office => BuildOfficeGlyph(),
                 ToastButtonKind.AiRedirect => BuildAiRedirectGlyph(),
                 _ => BuildDeleteGlyph()
@@ -636,6 +655,7 @@ public partial class SettingsWindow
         ToastButtonKind.Close => "close",
         ToastButtonKind.Pin => "pin",
         ToastButtonKind.Save => "save",
+        ToastButtonKind.Copy => "copy",
         ToastButtonKind.Office => "office export",
         ToastButtonKind.AiRedirect => "AI redirect",
         ToastButtonKind.Delete => "delete",
@@ -674,6 +694,7 @@ public partial class SettingsWindow
     private static System.Windows.Controls.Image BuildCloseGlyph() => BuildFluentIcon("close");
     private static System.Windows.Controls.Image BuildPinGlyph() => BuildFluentIcon("pin");
     private static System.Windows.Controls.Image BuildSaveGlyph() => BuildFluentIcon("download");
+    private static System.Windows.Controls.Image BuildCopyGlyph() => BuildFluentIcon("copy");
     private static System.Windows.Controls.Image BuildOfficeGlyph() => BuildFluentIcon("copy");
     private static System.Windows.Controls.Image BuildAiRedirectGlyph()
     {

--- a/src/OddSnap/UI/SettingsWindow.xaml
+++ b/src/OddSnap/UI/SettingsWindow.xaml
@@ -2002,6 +2002,80 @@
                                Visibility="Collapsed"
                                Margin="4,8,0,0"/>
 
+                    <TextBlock Text="Temporary overlay" Style="{StaticResource SectionLabel}" Margin="4,16,0,9"/>
+
+                    <Border Style="{StaticResource Card}">
+                        <StackPanel>
+                            <Grid Style="{StaticResource SettingRow}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource SettingIconFrame}">
+                                    <TextBlock Text="&#xE7C3;" Style="{StaticResource SettingIconGlyph}"/>
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="Temporary capture mode" Style="{StaticResource SettingTitle}"/>
+                                    <TextBlock Text="Show captures in a temporary overlay. Nothing is written to disk until you click Save." Style="{StaticResource SettingDescription}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <CheckBox x:Name="TemporaryCaptureModeCheck" Grid.Column="2" Content="" FontSize="13" VerticalAlignment="Center"
+                                          ToolTip="Show captures in a temporary overlay instead of saving them automatically."
+                                          AutomationProperties.Name="Temporary capture mode"
+                                          Checked="TemporaryCaptureModeCheck_Changed" Unchecked="TemporaryCaptureModeCheck_Changed"/>
+                            </Grid>
+                            <Border Height="1" Background="{DynamicResource ThemeSeparatorBrush}" Margin="0,9,0,9"/>
+                            <Grid Style="{StaticResource SettingRow}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource SettingIconFrame}">
+                                    <TextBlock Text="&#xE916;" Style="{StaticResource SettingIconGlyph}"/>
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="Overlay timeout" Style="{StaticResource SettingTitle}"/>
+                                    <TextBlock Text="How long the temporary overlay stays on screen before auto-dismissing." Style="{StaticResource SettingDescription}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <ComboBox x:Name="OverlayTimeoutCombo" Grid.Column="2" MinWidth="150"
+                                          VerticalAlignment="Center"
+                                          AutomationProperties.Name="Overlay timeout"
+                                          ToolTip="How long the temporary overlay stays on screen before auto-dismissing."
+                                          SelectionChanged="OverlayTimeoutCombo_SelectionChanged">
+                                    <ComboBoxItem Content="5 seconds" Tag="5"
+                                                  AutomationProperties.Name="5 second overlay timeout"/>
+                                    <ComboBoxItem Content="10 seconds" Tag="10"
+                                                  AutomationProperties.Name="10 second overlay timeout"/>
+                                    <ComboBoxItem Content="30 seconds" Tag="30"
+                                                  AutomationProperties.Name="30 second overlay timeout"/>
+                                    <ComboBoxItem Content="Never" Tag="0"
+                                                  AutomationProperties.Name="No overlay timeout"
+                                                  AutomationProperties.HelpText="Pin the overlay so it stays open until dismissed."/>
+                                </ComboBox>
+                            </Grid>
+                            <Border Height="1" Background="{DynamicResource ThemeSeparatorBrush}" Margin="0,9,0,9"/>
+                            <Grid Style="{StaticResource SettingRow}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource SettingIconFrame}">
+                                    <TextBlock Text="&#xE16F;" Style="{StaticResource SettingIconGlyph}"/>
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock Text="Copy to clipboard automatically" Style="{StaticResource SettingTitle}"/>
+                                    <TextBlock Text="Copy the temporary capture to the clipboard as soon as it is taken." Style="{StaticResource SettingDescription}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <CheckBox x:Name="CopyAfterCaptureCheck" Grid.Column="2" Content="" FontSize="13" VerticalAlignment="Center"
+                                          ToolTip="Copy the temporary capture to the clipboard automatically."
+                                          AutomationProperties.Name="Copy to clipboard automatically"
+                                          Checked="CopyAfterCaptureCheck_Changed" Unchecked="CopyAfterCaptureCheck_Changed"/>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
                     <TextBlock Text="Search" Style="{StaticResource SectionLabel}" Margin="4,16,0,9"/>
                     <Border x:Name="GeneralImageSearchSettingsCard" Style="{StaticResource Card}">
                         <StackPanel>
@@ -2494,6 +2568,23 @@
                                                             Drop="ToastLayoutButton_Drop"
                                                             Tag="Save">
                                                         <Image x:Name="ToastLayoutSaveIcon" Width="14" Height="14" Stretch="Uniform" Opacity="0.9"
+                                                               RenderOptions.BitmapScalingMode="HighQuality"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                    </Border>
+                                                    <Border x:Name="ToastLayoutCopyBtn"
+                                                            Width="30" Height="30" CornerRadius="9"
+                                                            Background="Transparent" BorderBrush="Transparent" BorderThickness="0"
+                                                            Cursor="Hand"
+                                                            ToolTip="Move the copy toast button"
+                                                            AutomationProperties.Name="Copy toast button"
+                                                            AllowDrop="True"
+                                                            MouseLeftButtonDown="ToastLayoutButton_MouseLeftButtonDown"
+                                                            MouseMove="ToastLayoutButton_MouseMove"
+                                                            MouseLeftButtonUp="ToastLayoutButton_MouseLeftButtonUp"
+                                                            DragEnter="ToastLayoutButton_DragEnter"
+                                                            Drop="ToastLayoutButton_Drop"
+                                                            Tag="Copy">
+                                                        <Image x:Name="ToastLayoutCopyIcon" Width="14" Height="14" Stretch="Uniform" Opacity="0.9"
                                                                RenderOptions.BitmapScalingMode="HighQuality"
                                                                HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                                     </Border>

--- a/src/OddSnap/UI/SettingsWindow.xaml.cs
+++ b/src/OddSnap/UI/SettingsWindow.xaml.cs
@@ -701,6 +701,66 @@ public partial class SettingsWindow : Window
             value => AskFileNameCheck.IsChecked = value);
     }
 
+    private void TemporaryCaptureModeCheck_Changed(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded || _suppressCaptureSavePreferenceChange) return;
+
+        var previous = _settingsService.Settings.TemporaryCaptureMode;
+        var selected = TemporaryCaptureModeCheck.IsChecked == true;
+        UpdateCaptureSavePreference(
+            "settings.temporary-capture-mode",
+            "Temporary capture mode",
+            previous,
+            selected,
+            value => _settingsService.Settings.TemporaryCaptureMode = value,
+            value => TemporaryCaptureModeCheck.IsChecked = value);
+    }
+
+    private void CopyAfterCaptureCheck_Changed(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded || _suppressCaptureSavePreferenceChange) return;
+
+        var previous = _settingsService.Settings.CopyAfterCapture;
+        var selected = CopyAfterCaptureCheck.IsChecked == true;
+        UpdateCaptureSavePreference(
+            "settings.copy-after-capture",
+            "Copy to clipboard automatically",
+            previous,
+            selected,
+            value => _settingsService.Settings.CopyAfterCapture = value,
+            value => CopyAfterCaptureCheck.IsChecked = value);
+    }
+
+    private void OverlayTimeoutCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _suppressCaptureSavePreferenceChange) return;
+
+        var selectedIndex = OverlayTimeoutCombo.SelectedIndex;
+        var selectedSeconds = selectedIndex switch
+        {
+            0 => 5,
+            1 => 10,
+            2 => 30,
+            3 => 0,
+            _ => 10
+        };
+        var previous = _settingsService.Settings.OverlayTimeoutSeconds;
+        UpdateCaptureSavePreference(
+            "settings.overlay-timeout",
+            "Overlay timeout",
+            previous,
+            selectedSeconds,
+            value => _settingsService.Settings.OverlayTimeoutSeconds = value,
+            value => OverlayTimeoutCombo.SelectedIndex = value switch
+            {
+                5 => 0,
+                10 => 1,
+                30 => 2,
+                0 => 3,
+                _ => 1
+            });
+    }
+
     private void LoadFileNameTemplate(string currentTemplate)
     {
         FileNameTemplateBox.Text = currentTemplate;

--- a/src/OddSnap/UI/ToastSpec.cs
+++ b/src/OddSnap/UI/ToastSpec.cs
@@ -27,6 +27,8 @@ internal sealed record ToastSpec
     public double? PreviewMaxHeight { get; init; }
     public int? MaxWidthOverride { get; init; }
     public int? MinWidthOverride { get; init; }
+    /// <summary>Per-spec auto-dismiss duration in seconds. Null falls back to the global ToastDurationSeconds.</summary>
+    public double? Duration { get; init; }
 
     public static ToastSpec Standard(string title, string body = "", string? filePath = null) => new()
     {

--- a/src/OddSnap/UI/ToastWindow.Static.cs
+++ b/src/OddSnap/UI/ToastWindow.Static.cs
@@ -15,7 +15,12 @@ public partial class ToastWindow
     private const string DefaultImagePreviewTitle = "";
 
     public static void SetPosition(OddSnap.Models.ToastPosition position) => _position = position;
-    public static void SetDuration(double seconds) => _durationSeconds = Math.Clamp(seconds, 1, 10);
+    public static void SetDuration(double seconds)
+    {
+        var clamped = Math.Clamp(seconds, 1, 60);
+        _baseDurationSeconds = clamped;
+        _durationSeconds = clamped;
+    }
     public static void SetButtonLayout(Models.AppSettings.ToastButtonLayoutSettings? layout)
     {
         _buttonLayout = layout is null
@@ -28,6 +33,8 @@ public partial class ToastWindow
                 PinSlot = layout.PinSlot,
                 ShowSave = layout.ShowSave,
                 SaveSlot = layout.SaveSlot,
+                ShowCopy = layout.ShowCopy,
+                CopySlot = layout.CopySlot,
                 ShowOffice = layout.ShowOffice,
                 OfficeSlot = layout.OfficeSlot,
                 ShowAiRedirect = layout.ShowAiRedirect,
@@ -104,6 +111,18 @@ public partial class ToastWindow
             autoPin,
             transparentShell: false,
             showOverlayButtons: true));
+    }
+
+    public static void ShowImagePreviewWithDuration(Bitmap screenshot, string? filePath, bool autoPin, double durationSeconds)
+    {
+        Show(ToastSpec.ImagePreview(
+            screenshot,
+            DefaultImagePreviewTitle,
+            string.Empty,
+            filePath,
+            autoPin,
+            transparentShell: false,
+            showOverlayButtons: true) with { Duration = durationSeconds });
     }
 
     public static void ShowImagePreview(Bitmap screenshot, string title, string body, string? filePath, bool autoPin, string? clickActionUrl, string? clickActionLabel)

--- a/src/OddSnap/UI/ToastWindow.xaml
+++ b/src/OddSnap/UI/ToastWindow.xaml
@@ -91,6 +91,20 @@
                                RenderOptions.BitmapScalingMode="HighQuality"
                                HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Border>
+                    <Border x:Name="CopyBtn" Width="32" Height="32" CornerRadius="8"
+                            Background="Transparent" BorderBrush="Transparent" BorderThickness="0"
+                            ToolTip="Copy preview"
+                            AutomationProperties.Name="Copy preview"
+                            AutomationProperties.HelpText="Copy this preview image to the clipboard."
+                            Cursor="Hand"
+                            Focusable="True"
+                            KeyDown="CopyBtn_KeyDown"
+                            HorizontalAlignment="Right" VerticalAlignment="Top"
+                            Margin="0,8,48,0" Opacity="0" Visibility="Collapsed">
+                        <Image x:Name="CopyIcon" Width="16" Height="16" Stretch="Uniform" Opacity="1"
+                               RenderOptions.BitmapScalingMode="HighQuality"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
                     <Border x:Name="OfficeBtn" Width="32" Height="32" CornerRadius="8"
                             Background="Transparent" BorderBrush="Transparent" BorderThickness="0"
                             ToolTip="Open with or send to Office"

--- a/src/OddSnap/UI/ToastWindow.xaml.cs
+++ b/src/OddSnap/UI/ToastWindow.xaml.cs
@@ -23,6 +23,7 @@ public partial class ToastWindow : Window
     private bool _isHovered;
     private bool _isFading;
     private bool _isSavingPreview;
+    private bool _isCopyingPreview;
     private bool _isOpeningAiRedirect;
     private bool _isDeletingSavedFile;
     private bool _isRunningOfficeAction;
@@ -37,6 +38,7 @@ public partial class ToastWindow : Window
     private static ToastWindow? _current;
     private static OddSnap.Models.ToastPosition _position = OddSnap.Models.ToastPosition.Right;
     private static double _durationSeconds = 2.5;
+    private static double _baseDurationSeconds = 2.5;
     private static bool _fadeOutEnabled;
     private static double _fadeOutSeconds = 1.0;
     private static Models.AppSettings.ToastButtonLayoutSettings _buttonLayout = new();
@@ -229,6 +231,12 @@ public partial class ToastWindow : Window
     private void ApplySpec(ToastSpec spec)
     {
         _isPinned = false;
+        // Per-spec duration override falls back to the configured base duration.
+        // Confirmation toasts after a temporary-overlay capture should dismiss using the base value,
+        // not the longer overlay timeout that drove the previous spec.
+        _durationSeconds = spec.Duration.HasValue
+            ? Math.Clamp(spec.Duration.Value, 1, 60)
+            : _baseDurationSeconds;
         ConfigureShell();
         ProgressBar.Visibility = Visibility.Visible;
         ApplyToastOverlayButtonVisual(PinBtn, PinIcon, "pin", active: false);
@@ -283,6 +291,7 @@ public partial class ToastWindow : Window
             CloseBtn.Visibility = Visibility.Collapsed;
             PinBtn.Visibility = Visibility.Collapsed;
             SaveBtn.Visibility = Visibility.Collapsed;
+            CopyBtn.Visibility = Visibility.Collapsed;
         }
 
         if (spec.TransparentShell)
@@ -421,12 +430,14 @@ public partial class ToastWindow : Window
         CloseIcon.Source = FluentIcons.RenderWpf("close", IconWhite, 20);
         PinIcon.Source = FluentIcons.RenderWpf("pin", IconWhite, 20);
         SaveIcon.Source = FluentIcons.RenderWpf("download", IconWhite, 20);
+        CopyIcon.Source = FluentIcons.RenderWpf("copy", IconWhite, 20);
         OfficeIcon.Source = FluentIcons.RenderWpf("copy", IconWhite, 20);
         AiRedirectIcon.Source = ToolIcons.RenderAiRedirectWpf(System.Drawing.Color.FromArgb(230, 255, 255, 255), 20);
         DeleteIcon.Source = FluentIcons.RenderWpf("trash", IconWhite, 20);
         ApplyToastOverlayButtonVisual(CloseBtn, CloseIcon, "close", active: false);
         ApplyToastOverlayButtonVisual(PinBtn, PinIcon, "pin", active: false);
         ApplyToastOverlayButtonVisual(SaveBtn, SaveIcon, "download", active: false);
+        ApplyToastOverlayButtonVisual(CopyBtn, CopyIcon, "copy", active: false);
         ApplyToastOverlayButtonVisual(OfficeBtn, OfficeIcon, "copy", active: false);
         ApplyAiRedirectOverlayButtonVisual(AiRedirectBtn, AiRedirectIcon, active: false);
         ApplyToastOverlayButtonVisual(DeleteBtn, DeleteIcon, "trash", active: false);
@@ -435,6 +446,7 @@ public partial class ToastWindow : Window
         HookOverlayHover(CloseBtn, CloseIcon, "close");
         HookOverlayHover(PinBtn, PinIcon, "pin");
         HookOverlayHover(SaveBtn, SaveIcon, "download");
+        HookOverlayHover(CopyBtn, CopyIcon, "copy");
         HookOverlayHover(OfficeBtn, OfficeIcon, "copy");
         HookAiRedirectHover(AiRedirectBtn, AiRedirectIcon);
         HookOverlayHover(DeleteBtn, DeleteIcon, "trash");
@@ -486,6 +498,7 @@ public partial class ToastWindow : Window
         CloseBtn.MouseLeftButtonDown -= CloseBtn_MouseLeftButtonDown;
         PinBtn.MouseLeftButtonDown -= PinBtn_MouseLeftButtonDown;
         SaveBtn.MouseLeftButtonDown -= SaveBtn_MouseLeftButtonDown;
+        CopyBtn.MouseLeftButtonDown -= CopyBtn_MouseLeftButtonDown;
         OfficeBtn.MouseLeftButtonDown -= OfficeBtn_MouseLeftButtonDown;
         AiRedirectBtn.MouseLeftButtonDown -= AiRedirectBtn_MouseLeftButtonDown;
         DeleteBtn.MouseLeftButtonDown -= DeleteBtn_MouseLeftButtonDown;
@@ -500,6 +513,7 @@ public partial class ToastWindow : Window
         CloseBtn.MouseLeftButtonDown += CloseBtn_MouseLeftButtonDown;
         PinBtn.MouseLeftButtonDown += PinBtn_MouseLeftButtonDown;
         SaveBtn.MouseLeftButtonDown += SaveBtn_MouseLeftButtonDown;
+        CopyBtn.MouseLeftButtonDown += CopyBtn_MouseLeftButtonDown;
         OfficeBtn.MouseLeftButtonDown += OfficeBtn_MouseLeftButtonDown;
         AiRedirectBtn.MouseLeftButtonDown += AiRedirectBtn_MouseLeftButtonDown;
         DeleteBtn.MouseLeftButtonDown += DeleteBtn_MouseLeftButtonDown;
@@ -510,6 +524,7 @@ public partial class ToastWindow : Window
         ApplyOverlayButton(CloseBtn, Helpers.ToastButtonKind.Close);
         ApplyOverlayButton(PinBtn, Helpers.ToastButtonKind.Pin);
         ApplyOverlayButton(SaveBtn, Helpers.ToastButtonKind.Save);
+        ApplyOverlayButton(CopyBtn, Helpers.ToastButtonKind.Copy);
         ApplyOverlayButton(OfficeBtn, Helpers.ToastButtonKind.Office);
         ApplyOverlayButton(AiRedirectBtn, Helpers.ToastButtonKind.AiRedirect);
         ApplyOverlayButton(DeleteBtn, Helpers.ToastButtonKind.Delete);
@@ -581,6 +596,9 @@ public partial class ToastWindow : Window
             Helpers.ToastButtonKind.Save => _isSavingPreview
                 ? ("Saving preview", "Save is already running.")
                 : ("Save preview", "Save this preview image."),
+            Helpers.ToastButtonKind.Copy => _isCopyingPreview
+                ? ("Copying preview", "Copy is already running.")
+                : ("Copy preview", "Copy this preview image to the clipboard."),
             Helpers.ToastButtonKind.Office => _isRunningOfficeAction
                 ? ("Office action running", "Open with or Office export is already running.")
                 : ("Open with or send to Office", "Open this preview with another app or send it to Office."),
@@ -632,7 +650,7 @@ public partial class ToastWindow : Window
         }
 
         e.Handled = true;
-        TogglePinned();
+        HandlePinPressed();
     }
 
     private void PinBtn_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
@@ -641,7 +659,53 @@ public partial class ToastWindow : Window
             return;
 
         e.Handled = true;
+        HandlePinPressed();
+    }
+
+    private void HandlePinPressed()
+    {
+        // Temporary captures (no backing file yet) "pin" by promoting to a movable floating window.
+        // This runs whether the toast is currently pinned (e.g. when OverlayTimeoutSeconds=Never)
+        // or not. Legacy previews that already have a saved file keep the in-place freeze behavior.
+        if (_previewBitmap is not null && !HasSavedFileOnDisk())
+        {
+            if (PromoteToPinnedFloatingWindow())
+                return;
+        }
+
         TogglePinned();
+    }
+
+    private bool PromoteToPinnedFloatingWindow()
+    {
+        if (_previewBitmap is null)
+            return false;
+
+        Bitmap clone;
+        try
+        {
+            clone = new Bitmap(_previewBitmap);
+        }
+        catch (Exception ex)
+        {
+            AppDiagnostics.LogWarning("toast.pin.clone-bitmap", ex.Message, ex);
+            return false;
+        }
+
+        try
+        {
+            var window = new PinnedCaptureWindow(clone, GetExistingSavedFilePathOrNull());
+            window.Show();
+        }
+        catch (Exception ex)
+        {
+            clone.Dispose();
+            AppDiagnostics.LogError("toast.pin.show-floating", ex, "Could not promote toast preview to a pinned floating window.");
+            return false;
+        }
+
+        DismissAnimated();
+        return true;
     }
 
     private void SaveBtn_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -663,6 +727,74 @@ public partial class ToastWindow : Window
 
         e.Handled = true;
         SavePreview();
+    }
+
+    private void CopyBtn_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (!CanActivateMouseControl(sender))
+        {
+            e.Handled = true;
+            return;
+        }
+
+        e.Handled = true;
+        CopyPreviewToClipboard();
+    }
+
+    private void CopyBtn_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (!CanActivateKeyboardControl(sender, e))
+            return;
+
+        e.Handled = true;
+        CopyPreviewToClipboard();
+    }
+
+    private void CopyPreviewToClipboard()
+    {
+        if (_previewBitmap is null || _isCopyingPreview)
+            return;
+
+        _isCopyingPreview = true;
+        CopyBtn.IsEnabled = false;
+        RefreshOverlayButtonAccessibility(CopyBtn, Helpers.ToastButtonKind.Copy);
+        string? feedbackName = null;
+        string? feedbackHelpText = null;
+        try
+        {
+            ClipboardService.CopyToClipboard(_previewBitmap, GetExistingSavedFilePathOrNull());
+            feedbackName = "Copied preview";
+            feedbackHelpText = "Copied preview to clipboard.";
+        }
+        catch (Exception ex)
+        {
+            feedbackName = "Copy failed";
+            feedbackHelpText = BuildToastActionFailureBody("OddSnap could not copy the preview to the clipboard. Try again or save the capture and copy it manually.", ex.Message);
+            AppDiagnostics.LogWarning("toast.copy-preview", feedbackHelpText, ex);
+        }
+        finally
+        {
+            _isCopyingPreview = false;
+            CopyBtn.IsEnabled = true;
+            if (!string.IsNullOrWhiteSpace(feedbackName) && !string.IsNullOrWhiteSpace(feedbackHelpText))
+                ShowCopyActionStatus(feedbackName, feedbackHelpText);
+            else
+                RefreshOverlayButtonAccessibility(CopyBtn, Helpers.ToastButtonKind.Copy);
+        }
+    }
+
+    private void ShowCopyActionStatus(string name, string helpText)
+    {
+        SetToastElementAccessibility(CopyBtn, name, helpText);
+        var stateVersion = _toastStateVersion;
+        var resetTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1.6) };
+        resetTimer.Tick += (_, _) =>
+        {
+            resetTimer.Stop();
+            if (IsCurrentToastState(stateVersion) && !_isCopyingPreview)
+                RefreshOverlayButtonAccessibility(CopyBtn, Helpers.ToastButtonKind.Copy);
+        };
+        resetTimer.Start();
     }
 
     private static bool IsKeyboardActivateKey(System.Windows.Input.KeyEventArgs e) =>
@@ -693,6 +825,18 @@ public partial class ToastWindow : Window
             ApplyPinnedState(true);
             RegionOverlayForm.CloseTransientUi();
 
+            var settings = SettingsService.LoadStatic();
+            bool quickSave =
+                _savedFilePath is null
+                && settings is { AskForFileNameOnSave: false }
+                && !string.IsNullOrWhiteSpace(settings.SaveDirectory);
+
+            if (quickSave)
+            {
+                TryQuickSavePreview(settings!);
+                return;
+            }
+
             var dlg = new Microsoft.Win32.SaveFileDialog
             {
                 FileName = _savedFilePath != null ? Path.GetFileName(_savedFilePath) : "screenshot.png",
@@ -714,8 +858,10 @@ public partial class ToastWindow : Window
 
             try
             {
-                CaptureOutputService.SaveBitmap(_previewBitmap, dlg.FileName, format, jpegQuality: 92);
-                Show(ToastSpec.Standard("Saved", Path.GetFileName(dlg.FileName)));
+                CaptureOutputService.SaveBitmap(_previewBitmap, dlg.FileName, format, jpegQuality: settings?.JpegQuality ?? 92);
+                _savedFilePath = dlg.FileName;
+                App.TryTrackSavedCapture(dlg.FileName, _previewBitmap.Width, _previewBitmap.Height);
+                Show(ToastSpec.Standard("Saved", Path.GetFileName(dlg.FileName), dlg.FileName));
             }
             catch (Exception ex)
             {
@@ -731,6 +877,56 @@ public partial class ToastWindow : Window
             SaveBtn.IsEnabled = true;
             RefreshOverlayButtonAccessibility(SaveBtn, Helpers.ToastButtonKind.Save);
         }
+    }
+
+    private void TryQuickSavePreview(Models.AppSettings settings)
+    {
+        // Quick-save path: only the "Save" button takes the temporary capture to disk.
+        // Used when the preview was shown without a backing file (TemporaryCaptureMode)
+        // or whenever the user has AskForFileNameOnSave turned off.
+        if (_previewBitmap is null)
+            return;
+
+        var format = settings.CaptureImageFormat;
+        var extension = CaptureOutputService.GetExtension(format);
+        var baseName = Helpers.FileNameTemplate.Format(settings.FileNameTemplate, _previewBitmap.Width, _previewBitmap.Height);
+        var fileName = $"{baseName}.{extension}";
+        string savePath;
+        try
+        {
+            savePath = Helpers.CaptureSavePath.BuildAvailablePath(
+                settings.SaveDirectory,
+                fileName,
+                settings.SaveInMonthlyFolders);
+        }
+        catch (Exception ex)
+        {
+            Show(ToastSpec.Error(
+                "Save failed",
+                BuildToastActionFailureBody("OddSnap could not pick a save path. Check the save folder in Settings.", ex.Message),
+                GetExistingSavedFilePathOrNull()));
+            return;
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(savePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+            CaptureOutputService.SaveBitmap(_previewBitmap, savePath, format, settings.JpegQuality);
+        }
+        catch (Exception ex)
+        {
+            Show(ToastSpec.Error(
+                "Save failed",
+                BuildToastActionFailureBody("OddSnap could not save the preview to the configured folder. Check Settings -> Saving.", ex.Message),
+                GetExistingSavedFilePathOrNull()));
+            return;
+        }
+
+        _savedFilePath = savePath;
+        App.TryTrackSavedCapture(savePath, _previewBitmap.Width, _previewBitmap.Height);
+        Show(ToastSpec.Standard("Saved", Path.GetFileName(savePath), savePath));
     }
 
     private double PauseToastAutoDismiss()
@@ -1344,6 +1540,7 @@ public partial class ToastWindow : Window
     {
         CloseBtn.BeginAnimation(OpacityProperty, Motion.To(targetOpacity, 150, Motion.SmoothOut));
         SaveBtn.BeginAnimation(OpacityProperty, Motion.To(targetOpacity, 150, Motion.SmoothOut));
+        CopyBtn.BeginAnimation(OpacityProperty, Motion.To(targetOpacity, 150, Motion.SmoothOut));
         OfficeBtn.BeginAnimation(OpacityProperty, Motion.To(targetOpacity, 150, Motion.SmoothOut));
         AiRedirectBtn.BeginAnimation(OpacityProperty, Motion.To(targetOpacity, 150, Motion.SmoothOut));
         DeleteBtn.BeginAnimation(OpacityProperty, Motion.To(targetOpacity, 150, Motion.SmoothOut));
@@ -1594,6 +1791,7 @@ public partial class ToastWindow : Window
         IsChildOf(source, CloseBtn) ||
         IsChildOf(source, PinBtn) ||
         IsChildOf(source, SaveBtn) ||
+        IsChildOf(source, CopyBtn) ||
         IsChildOf(source, OfficeBtn) ||
         IsChildOf(source, AiRedirectBtn) ||
         IsChildOf(source, DeleteBtn) ||
@@ -1708,6 +1906,7 @@ public partial class ToastWindow : Window
         _closeAfterOpacityAnimation = false;
         _resumeDismissOnMouseLeave = false;
         _isSavingPreview = false;
+        _isCopyingPreview = false;
         _isOpeningAiRedirect = false;
         _isDeletingSavedFile = false;
         _isRunningOfficeAction = false;
@@ -1720,6 +1919,7 @@ public partial class ToastWindow : Window
         if (IsMouseCaptured)
             ReleaseMouseCapture();
         SaveBtn.IsEnabled = true;
+        CopyBtn.IsEnabled = true;
         AiRedirectBtn.IsEnabled = true;
         DeleteBtn.IsEnabled = true;
         OfficeBtn.IsEnabled = true;


### PR DESCRIPTION
## Summary

Adds a Shottr-style temporary capture overlay workflow for screenshots, with pinned floating captures and explicit save behavior.

## Changes

- Adds `Temporary capture mode`, `Overlay timeout`, and `Copy to clipboard automatically` settings.
- Shows temporary captures in-memory without auto-saving or adding history until Save is clicked.
- Adds a floating pinned capture window with copy, save, close, and opacity controls.
- Adds a Copy button to image preview toasts and wires it into the toast button layout designer.
- Tracks saved temporary captures in history after the explicit save path.
- Ignores local `.claude/` and `.codex-tmp/` directories.

## Verification

- `dotnet build src/OddSnap/OddSnap.csproj --no-restore -v:minimal`
- Build succeeded with 0 warnings and 0 errors.